### PR TITLE
fix: make rpc compatible with geth 1.11.6

### DIFF
--- a/libs/jsonRPCClient.php
+++ b/libs/jsonRPCClient.php
@@ -119,7 +119,8 @@ class jsonRPCClient {
 		$request = array(
 						'method' => $method,
 						'params' => $params,
-						'id' => $currentId
+						'id' => $currentId,
+						'jsonrpc' => "2.0"
 						);
 		$request = json_encode($request);
 		$this->debug && $this->debug.='***** Request *****'."\n".$request."\n".'***** End Of request *****'."\n\n";


### PR DESCRIPTION
``geth`` 1.11 seems to require more strict compliance to jsonrpc 2.0 specs.